### PR TITLE
Address Non-Determinism in Unit Test

### DIFF
--- a/src/test/java/com/sap/oss/phosphor/fosstars/data/artifact/VulnerabilitiesFromOwaspDependencyCheckTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/data/artifact/VulnerabilitiesFromOwaspDependencyCheckTest.java
@@ -11,11 +11,12 @@ import com.sap.oss.phosphor.fosstars.data.owasp.model.OwaspDependencyCheckEntry;
 import com.sap.oss.phosphor.fosstars.model.subject.oss.MavenArtifact;
 import com.sap.oss.phosphor.fosstars.model.value.ValueHashSet;
 import com.sap.oss.phosphor.fosstars.model.value.Vulnerabilities;
-import com.sap.oss.phosphor.fosstars.model.value.Vulnerability;
 import com.sap.oss.phosphor.fosstars.util.Json;
 import java.io.File;
 import java.io.IOException;
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.Test;
 
 public class VulnerabilitiesFromOwaspDependencyCheckTest {
@@ -49,8 +50,9 @@ public class VulnerabilitiesFromOwaspDependencyCheckTest {
     Vulnerabilities vulnerabilities = values.of(VULNERABILITIES_IN_ARTIFACT).get().get();
     assertEquals(3, vulnerabilities.size());
 
-    Vulnerability vulnerability = vulnerabilities.entries().iterator().next();
-    assertEquals("CVE-2018-11307", vulnerability.id());
+    Set<String> vulnerabilityIds = new HashSet<>();
+    vulnerabilities.entries().forEach((vulnerability) -> vulnerabilityIds.add(vulnerability.id()));
+    assertTrue(vulnerabilityIds.contains("CVE-2018-11307"));
   }
 
   @Test


### PR DESCRIPTION
**Description**

This PR addresses non-deterministic behavior in the test `com.sap.oss.phosphor.fosstars.data.artifact.VulnerabilitiesFromOwaspDependencyCheckTest.testVulnerabilitiesAvailable`. The non-deterministic behavior comes from assuming a specific order from using the `HashSet` iterator. As stated by the Javadoc, "It makes no guarantees as to the iteration order of the set; in particular, it does not guarantee that the order will remain constant over time." This issue was found by the tool [NonDex](https://github.com/TestingResearchIllinois/NonDex).

**Solution**
All of the vulnerability id's can be added into a set. Then, the specific string can be searched for in the `HashSet`. This ensures that the test will always pass even if the iteration order changes.